### PR TITLE
Correctly handle hi-dpi mobiles.

### DIFF
--- a/_includes/themes/twitter/default.html
+++ b/_includes/themes/twitter/default.html
@@ -5,6 +5,7 @@
     <title>{{ page.title }}</title>
     {% if page.description %}<meta name="description" content="{{ page.description }}">{% endif %}
     <meta name="author" content="{{ site.author.name }}">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
Media-query are great... Except phones tends to have hi-dpi now,
which leads to the actual resolution of the websites on the phone in
number of pixels to be higher than on desktop. Thus the css media-query
initially made for narrow screen don't trigger.

You now need to put in the HTML an instruction for the browser to "fake"
a css resolution to get the right layout.

--- 

Apologies but I like to read your blog on mobile and the layout was bad on hi-dpi mobile screen. I could (of course), stop reading but meh, I'm lazy. 

See attached screenshot narrow screen on desktop before/after (no changes)
![screen shot 2018-06-28 at 23 43 18](https://user-images.githubusercontent.com/335567/42062609-5f9064b8-7b2e-11e8-9362-91437da0c124.png)
![screen shot 2018-06-28 at 23 43 45](https://user-images.githubusercontent.com/335567/42062610-5fb18e2c-7b2e-11e8-8439-d124e197613b.png)

And mobile (my nexus 5x), before/after
![screenshot_20180628-234400](https://user-images.githubusercontent.com/335567/42062629-6cf9e476-7b2e-11e8-92a3-2d9fc9d124b0.png)

![screenshot_20180628-234238](https://user-images.githubusercontent.com/335567/42062628-6cdb8224-7b2e-11e8-96ca-7001b7139623.png)



One drawback are the Youtube video that are now larger than the width of the screen, but you can still click on them to play fullscreen so I guess it's ok...
